### PR TITLE
Add ActiveModel::Attributes#==.

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add ActiveModel::Attributes#==.
+
+    I want to be able to compare identity checks with == method.
+    Because I want to compare attribute identities,
+    but currently I have to go through the attribute method.
+
+    I wanted to use AttributeSet#== for the comparison to avoid creating
+    unnecessary objects, but since it does not return true if the value
+    before type cast are different, I used Attributes#attributes instead.
+
+    ```ruby
+    # before
+    UserModel.new(id: 1) == UserModel.new(id: 1) # false
+
+    # after
+    UserModel.new(id: 1) == UserModel.new(id: 1) # true
+    ```
+
+    *bonobono555*
+
 *   Custom attribute types that inherit from Active Model built-in types and do
     not override the `serialize` method will now benefit from an optimization
     when serializing attribute values for the database.

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -138,6 +138,14 @@ module ActiveModel
       super
     end
 
+    # Returns true if +comparison_object+ is the same exact object, or +comparison_object+
+    # is of the same type and +self+ and +comparison_object+ have the same attributes.
+    def ==(comparison_object)
+      super ||
+        comparison_object.instance_of?(self.class) &&
+          attributes == comparison_object.attributes
+    end
+
     private
       def _write_attribute(attr_name, value)
         @attributes.write_from_user(attr_name, value)

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -41,6 +41,20 @@ module ActiveModel
       end
     end
 
+    class ModelForEqualityTest
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :id, :integer
+    end
+
+    class ModelForInequalityTest
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :id, :integer
+    end
+
     test "models that proxy attributes do not conflict with models with generated methods" do
       ModelWithGeneratedAttributeMethods.new
 
@@ -174,6 +188,25 @@ module ActiveModel
       assert_raise(ArgumentError) do
         ModelForAttributesTest.attribute :foo, :unknown
       end
+    end
+
+    test "equality" do
+      a = ModelForEqualityTest.new
+      assert_equal(a, a)
+      assert_equal(a, ModelForEqualityTest.new)
+
+      b = ModelForEqualityTest.new(id: 1)
+      assert_equal(b, ModelForEqualityTest.new(id: 1))
+      assert_equal(b, ModelForEqualityTest.new(id: "1"))
+    end
+
+    test "inequality" do
+      a = ModelForEqualityTest.new(id: 1)
+      b = ModelForEqualityTest.new(id: 2)
+      c = ModelForInequalityTest.new(id: 2)
+
+      assert_not_equal(a, b)
+      assert_not_equal(b, c)
     end
   end
 end


### PR DESCRIPTION
### Motivation / Background

 Add ActiveModel::Attributes#==.

  I want to be able to compare identity checks with == method.
  Because I want to compare attribute identities,
  but currently I have to go through the attribute method.

  I wanted to use AttributeSet#== for the comparison to avoid creating
  unnecessary objects, but since it does not return true if the value
  before type cast are different, I used Attributes#attributes instead.

### Detail

  ```ruby
  # before
  UserModel.new(id: 1) == UserModel.new(id: 1) # false

  # after
  UserModel.new(id: 1) == UserModel.new(id: 1) # true
  ```

### Additional information

I wanted to use AttributeSet#== for the comparison to avoid creating unnecessary objects, but since it does not return true if the value before type cast are different, I used Attributes#attributes instead.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
* [ ] CI is passing.

